### PR TITLE
Replace NULL with `I` in `across(...)`

### DIFF
--- a/R/error_correct.R
+++ b/R/error_correct.R
@@ -42,7 +42,7 @@ error_correct_fn <- function(df,
       if (sort_descending) {
         fn <- dplyr::desc
       } else {
-        fn <- NULL
+        fn <- I
       }
       df <- dplyr::arrange(df, dplyr::across(dplyr::all_of(sort_col), fn), .by_group = TRUE)
     }

--- a/R/expand_df.R
+++ b/R/expand_df.R
@@ -73,7 +73,7 @@ expand_df_filter <- function(df,
       if (sort_descending) {
         fn <- dplyr::desc
       } else {
-        fn <- NULL
+        fn <- I
       }
       df <- dplyr::arrange(df, dplyr::across(sort_col, fn), .by_group = TRUE)
     }

--- a/R/merge_prediction.R
+++ b/R/merge_prediction.R
@@ -46,7 +46,7 @@ merge_prediction <- function(df,
         if (sort_descending) {
           fn <- dplyr::desc
         } else {
-          fn <- NULL
+          fn <- I
         }
         df <- dplyr::arrange(df, dplyr::across(sort_col, fn), .by_group = TRUE)
       }

--- a/R/model_error.R
+++ b/R/model_error.R
@@ -61,7 +61,7 @@ model_error <- function(df,
     if (sort_descending) {
       fn <- dplyr::desc
     } else {
-      fn <- NULL
+      fn <- I
     }
     df <- dplyr::arrange(df,
                          dplyr::across(dplyr::all_of(sort_col), fn),

--- a/R/predict_aarr.R
+++ b/R/predict_aarr.R
@@ -209,7 +209,7 @@ fit_aarr_model <- function(df,
     if (sort_descending) {
       fn <- dplyr::desc
     } else {
-      fn <- NULL
+      fn <- I
     }
     df <- dplyr::arrange(df, dplyr::across(dplyr::all_of(sort_col), fn), .by_group = TRUE)
   }

--- a/R/predict_average.R
+++ b/R/predict_average.R
@@ -57,7 +57,7 @@ predict_average_fn <- function(df,
       if (sort_descending) {
         fn <- dplyr::desc
       } else {
-        fn <- NULL
+        fn <- I
       }
       df <- dplyr::arrange(df, dplyr::across(sort_col, fn), .by_group = TRUE)
     }

--- a/R/predict_forecast.R
+++ b/R/predict_forecast.R
@@ -189,7 +189,7 @@ predict_forecast_data <- function(df,
     if (sort_descending) {
       fn <- dplyr::desc
     } else {
-      fn <- NULL
+      fn <- I
     }
     df <- dplyr::arrange(df, dplyr::across(dplyr::all_of(sort_col), fn), .by_group = TRUE)
   }
@@ -226,7 +226,7 @@ get_forecast_data <- function(df,
     if (sort_descending) {
       fn <- dplyr::desc
     } else {
-      fn <- NULL
+      fn <- I
     }
     df <- dplyr::arrange(df, dplyr::across(dplyr::all_of(sort_col), fn), .by_group = TRUE)
   }

--- a/R/predict_simple.R
+++ b/R/predict_simple.R
@@ -21,7 +21,7 @@ predict_simple_fn <- function(df,
     if (sort_descending) {
       fn <- dplyr::desc
     } else {
-      fn <- NULL
+      fn <- I
     }
     df <- dplyr::arrange(df, dplyr::across(sort_col, fn), .by_group = TRUE)
   }


### PR DESCRIPTION
Not sure when this became an invalid way to call `across()`, but it is now. This is a valid NULL function elsewhere, and should work here.